### PR TITLE
renovate-config-validatorでdefault.jsonを見るようにする

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -18,3 +18,5 @@ jobs:
           cache: npm
       - run: npm ci --prefer-offline
       - run: npx renovate-config-validator
+        env:
+          RENOVATE_CONFIG_FILE: default.json


### PR DESCRIPTION
`renovate-config-validator` で `default.json` を見るようにします。
参考: https://scrapbox.io/hiroxto/renovate-config-validator%E3%81%A7renovate.json%E4%BB%A5%E5%A4%96%E3%81%AE%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%92%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%99%E3%82%8B