### PR TITLE
PRを出すCIをpushでも動かす

### DIFF
--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -3,6 +3,9 @@ name: update-gitleaks
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -3,6 +3,9 @@ name: update-package
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   # npm installを実行し、package.jsonやpackage-lock.jsonに差分があればPRを作る


### PR DESCRIPTION
renovateが出したPRに対してPRが出されていてもマージされるケースがあるようなので ( https://github.com/dev-hato/sudden-death/pull/275 )、pushでも動かすようにしてrequiredにします。
https://github.com/dev-hato/renovate-config/pull/46 を前提としているので https://github.com/dev-hato/renovate-config/pull/46 に向けています。