### PR TITLE
actions-update-gitleaksの不要な設定削除

### DIFF
--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -32,5 +32,4 @@ jobs:
       - uses: dev-hato/actions-update-gitleaks@v0.0.10
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          super-linter-yml-file: .github/workflows/super-linter.yml
           repo-name: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
`actions-update-gitleaks` v0.0.10では `super-linter-yml-file` の設定は不要なので削除します。