### PR TITLE
同時に出すPRの数を1つに制限する

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,8 +4,6 @@
     ":dependencyDashboard",
     ":semanticPrefixFixDepsChoreOthers",
     ":autodetectPinVersions",
-    ":prHourlyLimit2",
-    ":prConcurrentLimit10",
     "group:monorepos",
     "group:recommended",
     "workarounds:all",
@@ -23,5 +21,6 @@
     "**/__fixtures__/**"
   ],
   "automerge": true,
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "prConcurrentLimit": 1
 }


### PR DESCRIPTION
同時に出すPRの数を1つに制限することで、rebaseによるCIの再実行を減らします。