### PR TITLE
PRの上限数を2にする

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,5 +6,5 @@
   ],
   "automerge": true,
   "platformAutomerge": true,
-  "prConcurrentLimit": 1
+  "prConcurrentLimit": 2
 }


### PR DESCRIPTION
PRがマージできない状態で置かれているとPRが出なくなってしまうので、上限数を2にします。