### PR TITLE
renovate-config-validator: --strict付与

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           cache: npm
       - run: npm ci --prefer-offline
-      - run: npx renovate-config-validator
+      - run: npx renovate-config-validator --strict
         env:
           RENOVATE_CONFIG_FILE: default.json
 

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -18,8 +18,6 @@ jobs:
           cache: npm
       - run: npm ci --prefer-offline
       - run: npx renovate-config-validator --strict
-        env:
-          RENOVATE_CONFIG_FILE: default.json
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -18,6 +18,8 @@ jobs:
           cache: npm
       - run: npm ci --prefer-offline
       - run: npx renovate-config-validator --strict
+        env:
+          RENOVATE_CONFIG_FILE: default.json
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
`default.json` や `renovate.json` のマイグレーションが必要な場合にCIが落ちるよう、 `renovate-config-validator` に `--strict` を付与します。