### PR TITLE
default.jsonをrenovate-config-validatorにかける

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .
+          RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES: default.json
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
`default.json` にrenovate-config-validatorをかけるようにします。

関連: https://github.com/super-linter/super-linter/pull/4674