### PR TITLE
renovate: 設定のmigrationのPRを出すようにする

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .
+          RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES: default.json
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
   "automerge": true,
   "platformAutomerge": true,
   "prConcurrentLimit": 2,
+  "configMigration": true,
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#configmigration

renovateの設定のmigrationのPRを出させることができるようなので設定してみます。
`default.json` のチェックを行えるよう、 https://github.com/dev-hato/renovate-config/pull/1376 を前提にしています。