### PR TITLE
renovate: Goパッケージのアップデート後にgo mod tidyを行う

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,6 +10,14 @@
   "configMigration": true,
   "packageRules": [
     {
+      "matchManagers": [
+        "gomod"
+      ],
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
+    },
+    {
       "matchPackageNames": [
         "npm"
       ],


### PR DESCRIPTION
renovate側でGoパッケージのアップデート後に `go mod tidy` を行う設定を入れます。