### PR TITLE
node-fetchダウングレード

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
+    "node-fetch": "2.6.12",
     "textlint": "14.7.1",
     "textlint-filter-rule-comments": "1.2.2",
     "textlint-rule-abbr-within-parentheses": "1.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>dev-hato/renovate-config"]
+  "extends": ["github>dev-hato/renovate-config"],
+  "ignoreDeps": ["node-fetch"]
 }


### PR DESCRIPTION
https://github.com/dev-hato/renovate-config/pull/1739, https://github.com/dev-hato/renovate-config/pull/1741 でsuper-linterの実行が終わらなくなっているので、 https://github.com/dev-hato/hato-atama/pull/3551 と同様に `node-fetch` を2.6.12で固定します。