### PR TITLE
3日以上経ったnpmパッケージのみをアップデート対象にする

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,6 +10,10 @@
       "postUpdateOptions": ["gomodTidy"]
     },
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "matchPackageNames": ["npm"],
       "enabled": false
     }


### PR DESCRIPTION
npmパッケージに脆弱性のあるコードが仕込まれていた場合、即座にアップデートすると良くないので、しばらく経ってからアップデートするようにします。
https://docs.renovatebot.com/configuration-options/#minimumreleaseage の例の通り、一旦3日以上経ったものにしていますが、日数に関しては議論の余地ありです。