### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -53,7 +53,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
+        uses: super-linter/super-linter/slim@7bba2eeb89d01dc9bfd93c497477a57e72c83240 # v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -61,6 +61,7 @@ jobs:
           RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES: default.json
           VALIDATE_JSCPD: false
           VALIDATE_GIT_COMMITLINT: false
+          VALIDATE_BIOME_FORMAT: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
https://github.com/dev-hato/renovate-config/pull/1821 をベースにsuper-linterをアップデートします。

https://github.com/dev-hato/renovate-config/actions/runs/18250764104/job/51964851441?pr=1821#step:6:161

```
  2025-10-04 23:15:20 [WARN]   Biome format and Prettier are both enabled for JSON files, and might conflict with each other. To avoid potential conflicts, keep only one of the two enabled, and disable the other.
```

`BIOME_FORMAT` と `JSON_PRETTIER` を同時に設定しているとコンフリクトが発生するので、現状と差分が発生しない後者のみを適用するようにしています。