### PR TITLE
CI Lint Code Base: PRへの書き込み権限付与

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: write
   statuses: write
 ###############
 # Set the Job #


### PR DESCRIPTION
https://github.com/dev-hato/renovate-config/actions/runs/24280038859/job/70900368840#step:6:375

```
2026-04-11 09:58:49 [WARN]   Failed to call GitHub API (https://api.github.com/repos/dev-hato/renovate-config/issues/1969/comments): curl: (22) The requested URL returned error: 403
```

上記Warningを解消するため、CI `Lint Code Base` に `pull-requests: write` を付与します。